### PR TITLE
Fixed out of bounds error while calculating checksum for odd-length ICMP v4 echo requests

### DIFF
--- a/src/main/java/org/opennms/protocols/icmp/ICMPEchoPacket.java
+++ b/src/main/java/org/opennms/protocols/icmp/ICMPEchoPacket.java
@@ -293,7 +293,7 @@ public final class ICMPEchoPacket extends ICMPHeader {
         // take care of any stray bytes
         //
         if ((m_pad.length % 2) == 1)
-            summer.add(m_pad[m_pad.length]);
+            summer.add(m_pad[m_pad.length - 1]);
 
         //
         // set the checksum in the header


### PR DESCRIPTION
Related to #NMS-7073.

Please review and merge.
